### PR TITLE
Enhance Slack integration with detailed cost breakdown

### DIFF
--- a/src/printers/slack.ts
+++ b/src/printers/slack.ts
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import { TotalCosts } from '../cost';
 
 /**
- * Formats the costs by service into a string
+ * Formats the costs by service for all time periods into a string
  *
  * @param costs Cost breakdown for account
  * @returns formatted message
@@ -10,15 +10,55 @@ import { TotalCosts } from '../cost';
 function formatServiceBreakdown(costs: TotalCosts): string {
   const serviceCosts = costs.totalsByService;
 
-  const sortedServices = Object.keys(serviceCosts.yesterday)
-    .filter((service) => serviceCosts.yesterday[service] > 0)
-    .sort((a, b) => serviceCosts.yesterday[b] - serviceCosts.yesterday[a]);
+  // Get all services that have any costs across all periods
+  const allServices = new Set([
+    ...Object.keys(serviceCosts.lastMonth),
+    ...Object.keys(serviceCosts.thisMonth),
+    ...Object.keys(serviceCosts.last7Days),
+    ...Object.keys(serviceCosts.yesterday)
+  ]);
 
-  const serviceCostsYesterday = sortedServices.map((service) => {
-    return `> ${service}: \`$${serviceCosts.yesterday[service].toFixed(2)}\``;
+  // Sort services by yesterday's costs (descending), then alphabetically
+  const sortedServices = Array.from(allServices).sort((a, b) => {
+    const costDiff = (serviceCosts.yesterday[b] || 0) - (serviceCosts.yesterday[a] || 0);
+    return costDiff !== 0 ? costDiff : a.localeCompare(b);
   });
 
-  return serviceCostsYesterday.join('\n');
+  // Filter out services that have zero costs across all periods
+  const servicesWithCosts = sortedServices.filter(service =>
+    (serviceCosts.lastMonth[service] || 0) > 0 ||
+    (serviceCosts.thisMonth[service] || 0) > 0 ||
+    (serviceCosts.last7Days[service] || 0) > 0 ||
+    (serviceCosts.yesterday[service] || 0) > 0
+  );
+
+  let breakdown = '';
+
+  // Format service breakdown for each time period
+  const periods = [
+    { name: 'Last Month', data: serviceCosts.lastMonth },
+    { name: 'This Month', data: serviceCosts.thisMonth },
+    { name: 'Last 7 Days', data: serviceCosts.last7Days },
+    { name: 'Yesterday', data: serviceCosts.yesterday }
+  ];
+
+  periods.forEach((period, index) => {
+    const servicesForPeriod = servicesWithCosts.filter(service =>
+      (period.data[service] || 0) > 0
+    );
+
+    if (servicesForPeriod.length > 0) {
+      if (index > 0) breakdown += '\n';
+      breakdown += `> *${period.name}:*\n`;
+
+      servicesForPeriod.forEach(service => {
+        const cost = period.data[service] || 0;
+        breakdown += `> • ${service}: \`$${cost.toFixed(2)}\`\n`;
+      });
+    }
+  });
+
+  return breakdown;
 }
 
 export async function notifySlack(
@@ -29,22 +69,15 @@ export async function notifySlack(
   slackChannel: string
 ) {
   const channel = slackChannel;
-
   const totals = costs.totals;
-  const serviceCosts = costs.totalsByService;
-
-  let serviceCostsYesterday = [];
-  Object.keys(serviceCosts.yesterday).forEach((service) => {
-    serviceCosts.yesterday[service].toFixed(2);
-    serviceCostsYesterday.push(`${service}: $${serviceCosts.yesterday[service].toFixed(2)}`);
-  });
 
   const summary = `> *Account: ${accountAlias}*
 
-> *Summary *
-> Total Yesterday: \`$${totals.yesterday.toFixed(2)}\`
-> Total This Month: \`$${totals.thisMonth.toFixed(2)}\`
+> *Summary*
 > Total Last Month: \`$${totals.lastMonth.toFixed(2)}\`
+> Total This Month: \`$${totals.thisMonth.toFixed(2)}\`
+> Total Last 7 Days: \`$${totals.last7Days.toFixed(2)}\`
+> Total Yesterday: \`$${totals.yesterday.toFixed(2)}\`
 `;
 
   const breakdown = `


### PR DESCRIPTION
- Add Last 7 Days total to summary section to match CLI output
- Include service breakdown for all time periods (Last Month, This Month, Last 7 Days, Yesterday)
- Group service costs by time period with clear headers
- Sort services by yesterday's costs for better readability
- Filter out services with zero costs across all periods

Fixes #5

<!--
  😀 Wonderful!  Thank you for opening a pull request.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request links relevant issues as `Fixes #5`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

<!--
  🎉 Thank you for contributing!
-->
